### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/app/src/main/java/org/refugerestrooms/database/SaveBathroomPropertyHandler.java
+++ b/app/src/main/java/org/refugerestrooms/database/SaveBathroomPropertyHandler.java
@@ -5,7 +5,10 @@ import org.refugerestrooms.database.model.BathroomEntity;
 import org.refugerestrooms.database.model.DaoSession;
 import org.refugerestrooms.models.Bathroom;
 
-public  class SaveBathroomPropertyHandler {
+public final class SaveBathroomPropertyHandler {
+
+    private SaveBathroomPropertyHandler() {}
+
     /**
      * Save property will take the bathroom object and convert it into a BathroomEntity Object
      * and then insert it into the daosession.

--- a/app/src/main/java/org/refugerestrooms/models/Haversine.java
+++ b/app/src/main/java/org/refugerestrooms/models/Haversine.java
@@ -4,8 +4,11 @@ package org.refugerestrooms.models;
  * Created by Refuge Restrooms on 7/13/2015.
  */
 //Haversine formula to compute shortest distance between two points on a sphere
-public class Haversine {
+public final class Haversine {
     public static final double R = 6372.8; // Radius of Earth in Kilometers
+
+    private Haversine () {}
+
     public static double formula(double lat1, double lng1, double lat2, double lng2) {
         double dLat = Math.toRadians(lat2 - lat1);
         double dLng = Math.toRadians(lng2 - lng1);

--- a/app/src/main/java/org/refugerestrooms/servers/RequestHandler.java
+++ b/app/src/main/java/org/refugerestrooms/servers/RequestHandler.java
@@ -15,9 +15,9 @@ import org.json.JSONObject;
  * To minimize volley requests  this handler is made to only take the url and
  * the success listener and the error listener.
  */
-public class RequestHandler {
+public final class RequestHandler {
 
-
+    private RequestHandler() {}
 
     /**
      * @param onSuccessListener Response.Listener<JSONObject>  on success listener

--- a/app/src/main/java/org/refugerestrooms/views/BathroomSpecsViewUpdater.java
+++ b/app/src/main/java/org/refugerestrooms/views/BathroomSpecsViewUpdater.java
@@ -16,7 +16,9 @@ import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-public class BathroomSpecsViewUpdater {
+public final class BathroomSpecsViewUpdater {
+
+    private BathroomSpecsViewUpdater() {}
 
     public static void update(View view, Bathroom bathroom, Context context) {
         TextView scoreTv = (TextView) view.findViewById(R.id.score);

--- a/restroomsdaogenerator/src/main/java/org/refugerestrooms/RestroomsDaoGenerator.java
+++ b/restroomsdaogenerator/src/main/java/org/refugerestrooms/RestroomsDaoGenerator.java
@@ -21,7 +21,7 @@ import de.greenrobot.daogenerator.Schema;
  * https://github.com/greenrobot/greenDAO
  * http://www.devteam83.com/en/tutorial-greendao-from-scratch-part-1/
  */
-public class RestroomsDaoGenerator {
+public final class RestroomsDaoGenerator {
 
 
     private static final String BATHROOM_ENTITY = "BathroomEntity";
@@ -42,6 +42,8 @@ public class RestroomsDaoGenerator {
     private static final String TIMESTAMP = "timestamp";
     private static final String GENERATE_IN_PATH = "../app/src/main/java";
     private static final String DATABASE_PACKAGE = "org.refugerestrooms.database.model";
+
+    private RestroomsDaoGenerator() {}
 
     public static void main(String args[]) throws Exception {
         initModel();

--- a/volley/src/main/java/com/android/volley/VolleyLog.java
+++ b/volley/src/main/java/com/android/volley/VolleyLog.java
@@ -29,10 +29,12 @@ import java.util.Locale;
  * to see Volley logs call:<br/>
  * {@code <android-sdk>/platform-tools/adb shell setprop log.tag.Volley VERBOSE}
  */
-public class VolleyLog {
+public final class VolleyLog {
     public static String TAG = "Volley";
 
     public static boolean DEBUG = Log.isLoggable(TAG, Log.VERBOSE);
+
+    private VolleyLog() {}
 
     /**
      * Customize the log tag for your application, so that other apps

--- a/volley/src/main/java/com/android/volley/toolbox/HttpHeaderParser.java
+++ b/volley/src/main/java/com/android/volley/toolbox/HttpHeaderParser.java
@@ -28,7 +28,9 @@ import java.util.Map;
 /**
  * Utility methods for parsing HTTP headers.
  */
-public class HttpHeaderParser {
+public final class HttpHeaderParser {
+
+    private HttpHeaderParser() {}
 
     /**
      * Extracts a {@link Cache.Entry} from a {@link NetworkResponse}.

--- a/volley/src/main/java/com/android/volley/toolbox/Volley.java
+++ b/volley/src/main/java/com/android/volley/toolbox/Volley.java
@@ -27,10 +27,12 @@ import com.android.volley.RequestQueue;
 
 import java.io.File;
 
-public class Volley {
+public final class Volley {
 
     /** Default on-disk cache directory. */
     private static final String DEFAULT_CACHE_DIR = "volley";
+
+    private Volley() {}
 
     /**
      * Creates a default instance of the worker pool and calls {@link RequestQueue#start()} on it.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat