### PR TITLE
squid:S2325, squid:SwitchLastCaseIsDefaultCheck, squid:MissingDepreca…

### DIFF
--- a/app/src/main/java/org/refugerestrooms/models/Bathroom.java
+++ b/app/src/main/java/org/refugerestrooms/models/Bathroom.java
@@ -247,7 +247,7 @@ public class Bathroom {
         return new LatLng(mLatitude, mLongitude);
     }
 
-    private String decodeString(String string) {
+    private static String decodeString(String string) {
         try {
             string = new String(string.getBytes("ISO-8859-1"),"UTF-8");
         } catch (UnsupportedEncodingException e) {

--- a/app/src/main/java/org/refugerestrooms/views/BathroomInfoWindow.java
+++ b/app/src/main/java/org/refugerestrooms/views/BathroomInfoWindow.java
@@ -77,7 +77,7 @@ public class BathroomInfoWindow implements GoogleMap.InfoWindowAdapter {
         return mInfoWindowView;
     }
     // This is used to fix encoding errors from the API
-    private String getStringInBytes(String string) {
+    private static String getStringInBytes(String string) {
         try {
             string = new String(string.getBytes("UTF-8"),"UTF-8");
         } catch (UnsupportedEncodingException e) {

--- a/app/src/main/java/org/refugerestrooms/views/InfoViewFragment.java
+++ b/app/src/main/java/org/refugerestrooms/views/InfoViewFragment.java
@@ -132,7 +132,7 @@ public class InfoViewFragment extends android.support.v4.app.Fragment {
         return text;
     }
     // This is used to fix encoding errors from the API
-    private String getStringInBytes(String string) {
+    private static String getStringInBytes(String string) {
         try {
             string = new String(string.getBytes("UTF-8"),"UTF-8");
         } catch (UnsupportedEncodingException e) {

--- a/app/src/main/java/org/refugerestrooms/views/MainActivity.java
+++ b/app/src/main/java/org/refugerestrooms/views/MainActivity.java
@@ -212,7 +212,11 @@ public class MainActivity extends ActionBarActivity
                          * Try the request again
                          */
                         break;
+                    default:
+                        break;
                 }
+                default:
+                    break;
         }
     }
 
@@ -706,7 +710,8 @@ public class MainActivity extends ActionBarActivity
                 } else {
                     // TODO something
                 }
-                return;
+            default:
+                break;
         }
     }
 
@@ -963,7 +968,6 @@ public class MainActivity extends ActionBarActivity
         FragmentManager fragmentManager = getSupportFragmentManager();
         Fragment mFragment = null;
         switch(position) {
-            default:
             case 0:
                 mTitle = getString(R.string.map_title_section);
                 mFragment = new MapFragment();
@@ -983,6 +987,8 @@ public class MainActivity extends ActionBarActivity
             case 3:
                 mTitle = getString(R.string.feedback_title_section);
                 mFragment = new FeedbackFormFragment();
+                break;
+            default:
                 break;
         }
         if (mFragment != null) {

--- a/app/src/main/java/org/refugerestrooms/views/TextDirectionsActivity.java
+++ b/app/src/main/java/org/refugerestrooms/views/TextDirectionsActivity.java
@@ -103,6 +103,8 @@ public class TextDirectionsActivity extends ActionBarActivity {
                 this.finish();
                 //NavUtils.navigateUpFromSameTask(this);
                 return true;
+            default:
+                break;
         }
         return super.onOptionsItemSelected(item);
 

--- a/volley/src/main/java/com/android/volley/Request.java
+++ b/volley/src/main/java/com/android/volley/Request.java
@@ -441,7 +441,7 @@ public abstract class Request<T> implements Comparable<Request<T>> {
     /**
      * Converts <code>params</code> into an application/x-www-form-urlencoded encoded string.
      */
-    private byte[] encodeParameters(Map<String, String> params, String paramsEncoding) {
+    private static byte[] encodeParameters(Map<String, String> params, String paramsEncoding) {
         StringBuilder encodedParams = new StringBuilder();
         try {
             for (Map.Entry<String, String> entry : params.entrySet()) {

--- a/volley/src/main/java/com/android/volley/toolbox/DiskBasedCache.java
+++ b/volley/src/main/java/com/android/volley/toolbox/DiskBasedCache.java
@@ -235,7 +235,7 @@ public class DiskBasedCache implements Cache {
      * @param key The key to generate a file name for.
      * @return A pseudo-unique filename.
      */
-    private String getFilenameForKey(String key) {
+    private static String getFilenameForKey(String key) {
         int firstHalfLength = key.length() / 2;
         String localFilename = String.valueOf(key.substring(0, firstHalfLength).hashCode());
         localFilename += String.valueOf(key.substring(firstHalfLength).hashCode());

--- a/volley/src/main/java/com/android/volley/toolbox/JsonRequest.java
+++ b/volley/src/main/java/com/android/volley/toolbox/JsonRequest.java
@@ -48,6 +48,7 @@ public abstract class JsonRequest<T> extends Request<T> {
      *
      * @deprecated Use {@link #JsonRequest(int, String, String, Listener, ErrorListener)}.
      */
+    @Deprecated
     public JsonRequest(String url, String requestBody, Listener<T> listener,
             ErrorListener errorListener) {
         this(Method.DEPRECATED_GET_OR_POST, url, requestBody, listener, errorListener);
@@ -71,6 +72,7 @@ public abstract class JsonRequest<T> extends Request<T> {
     /**
      * @deprecated Use {@link #getBodyContentType()}.
      */
+    @Deprecated
     @Override
     public String getPostBodyContentType() {
         return getBodyContentType();
@@ -79,6 +81,7 @@ public abstract class JsonRequest<T> extends Request<T> {
     /**
      * @deprecated Use {@link #getBody()}.
      */
+    @Deprecated
     @Override
     public byte[] getPostBody() {
         return getBody();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S2325 - "private" methods that don't access instance data should be "static"
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause
squid:MissingDeprecatedCheck - Deprecated elements should have both the annotation and the Javadoc tag

You can find more information about the issues here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2325
https://dev.eclipse.org/sonar/coding_rules#q=squid:SwitchLastCaseIsDefaultCheck
https://dev.eclipse.org/sonar/coding_rules#q=squid:MissingDeprecatedCheck

Please let me know if you have any questions.

M-Ezzat