### PR TITLE
Cleanup - squid:S1155 - Collection.isEmpty() should be used to test f…

### DIFF
--- a/volley/src/main/java/com/android/volley/Request.java
+++ b/volley/src/main/java/com/android/volley/Request.java
@@ -380,7 +380,7 @@ public abstract class Request<T> implements Comparable<Request<T>> {
         // call getPostParams() and getPostParamsEncoding() since legacy clients would have
         // overridden these two member functions for POST requests.
         Map<String, String> postParams = getPostParams();
-        if (postParams != null && postParams.size() > 0) {
+        if (postParams != null && !postParams.isEmpty()) {
             return encodeParameters(postParams, getPostParamsEncoding());
         }
         return null;
@@ -432,7 +432,7 @@ public abstract class Request<T> implements Comparable<Request<T>> {
      */
     public byte[] getBody() throws AuthFailureError {
         Map<String, String> params = getParams();
-        if (params != null && params.size() > 0) {
+        if (params != null && !params.isEmpty()) {
             return encodeParameters(params, getParamsEncoding());
         }
         return null;

--- a/volley/src/main/java/com/android/volley/VolleyLog.java
+++ b/volley/src/main/java/com/android/volley/VolleyLog.java
@@ -171,7 +171,7 @@ public final class VolleyLog {
 
         /** Returns the time difference between the first and last events in this log. */
         private long getTotalDuration() {
-            if (mMarkers.size() == 0) {
+            if (mMarkers.isEmpty()) {
                 return 0;
             }
 

--- a/volley/src/main/java/com/android/volley/toolbox/ImageLoader.java
+++ b/volley/src/main/java/com/android/volley/toolbox/ImageLoader.java
@@ -361,7 +361,7 @@ public class ImageLoader {
                 request = mBatchedResponses.get(mCacheKey);
                 if (request != null) {
                     request.removeContainerAndCancelIfNecessary(this);
-                    if (request.mContainers.size() == 0) {
+                    if (request.mContainers.isEmpty()) {
                         mBatchedResponses.remove(mCacheKey);
                     }
                 }
@@ -440,7 +440,7 @@ public class ImageLoader {
          */
         public boolean removeContainerAndCancelIfNecessary(ImageContainer container) {
             mContainers.remove(container);
-            if (mContainers.size() == 0) {
+            if (mContainers.isEmpty()) {
                 mRequest.cancel();
                 return true;
             }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 - Collection.isEmpty() should be used to test for emptiness

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1155

Please let me know if you have any questions.

M-Ezzat