### PR TITLE
Fix a couple of minor UI lints/warnings

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -56,7 +56,7 @@
                 android:layout_marginTop="60dp"
                 android:background="@drawable/search_here_button"
                 android:singleLine="true"
-                android:text="Search here.."
+                android:text="@string/search_here"
                 android:textAlignment="center"
                 android:visibility="invisible"
                 android:textColor="@color/common_google_signin_btn_text_dark_focused" />

--- a/app/src/main/res/layout/bathroom_info_window.xml
+++ b/app/src/main/res/layout/bathroom_info_window.xml
@@ -34,7 +34,8 @@
         android:layout_marginLeft="3dp"
         android:layout_marginStart="3dp"
         android:layout_marginBottom="-24dp"
-        android:layout_marginTop="-16dp" />
+        android:layout_marginTop="-16dp"
+        android:contentDescription="@string/accessible" />
 
     <ImageView
         android:id="@+id/unisex"
@@ -45,6 +46,7 @@
         android:layout_toEndOf="@id/window_snippet"
         android:layout_below="@id/accessible"
         android:layout_marginLeft="3dp"
-        android:layout_marginStart="3dp" />
+        android:layout_marginStart="3dp"
+        android:contentDescription="@string/unisex" />
 
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,4 +65,5 @@
     <string name="bathroom_details_address">3200 Chicago Ave\nMinneapolis, MN, US</string>
 
     <string name="map_api_key">AIzaSyBABBVsda23KF3TMrrbzYUqu6SClih5ZfA</string>
+    <string name="search_here">Search here..</string>
 </resources>


### PR DESCRIPTION
Hi folks,

I was messing around in Android Studio looking at the layouts (`app/src/main/res/layout/[these].xml`). Some warnings showed up in the graphical view for these layouts, so I took a shot at fixing them.

- Adds a text description for the unisex and accessible icons for a restroom. to help screen readers.
  - Reuses the existing `@string/accessible` and `@string/unisex` strings.
- Converts a hard-coded phrase "Search here.." into an `@string`
  - Not sure if this is in the right spot of `strings.xml`, which I'd say is pretty tidy and organized; I'm happy to move the new string to a different line for organization's sake.

Let me know if there's anything you'd change in this. I'm okay if it turns out there's a reason not to merge these things. Just getting a sense of Android Studio.