### PR TITLE
README.md: Update badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Refuge Restrooms for Android
-[![License](https://img.shields.io/badge/license-AGPL-lightgrey.svg)](https://raw.githubusercontent.com/RefugeRestrooms/refugerestrooms-ios/master/LICENSE)
-![Android](https://img.shields.io/badge/platform-android-lightgrey.svg)
-[![Travis](https://travis-ci.org/RefugeRestrooms/refugerestrooms-android.svg?branch=master)](https://travis-ci.org/RefugeRestrooms/refugerestrooms-android)
+[![license: AGPL](https://img.shields.io/badge/license-AGPL-lightgrey.svg)](https://raw.githubusercontent.com/RefugeRestrooms/refugerestrooms-ios/master/LICENSE)
+![platform: android](https://img.shields.io/badge/platform-android-lightgrey.svg)
+[![Travis CI Build Status](https://travis-ci.org/RefugeRestrooms/refugerestrooms-android.svg?branch=master)](https://travis-ci.org/RefugeRestrooms/refugerestrooms-android)
 
-[![App Store Badge](https://cloud.githubusercontent.com/assets/16610908/18124896/7be337b6-6f74-11e6-9814-79b9c2d53961.png)](https://play.google.com/store/apps/details?id=org.refugerestrooms)
+[![Play Store Badge](https://cloud.githubusercontent.com/assets/16610908/18124896/7be337b6-6f74-11e6-9814-79b9c2d53961.png)](https://play.google.com/store/apps/details?id=org.refugerestrooms)
 
 Android app for [Refuge Restrooms](http://www.refugerestrooms.org/)
 


### PR DESCRIPTION
Hi folks,

I just realized the build status badges are still pointing to our old Travis URL (travis-ci.org), so I figured I could do a quick PR to update them.

Also changed alt-text in a couple of the badges so they convey the content of the image. (iOS already reads the actual text from the badge SVGs, so this doesn't really affect iOS VoiceOver users, but I have heard screen readers are pretty inconsistent about what they read aloud vs what they don't.)

Also changed alt text "App Store" --> "Play Store" for the Google Play badge. 