### PR TITLE
.travis.yml: Change dist: "precise" --> "trusty"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: android
+dist: trusty
 sudo: required
 jdk: oraclejdk8
 android:
@@ -44,4 +45,3 @@ before_script:
 script:
   - android list target
   - ./gradlew connectedAndroidTest -PdisablePreDex
-dist: precise


### PR DESCRIPTION
From https://docs.travis-ci.com/user/languages/android/#overview

"Android builds are only supported on our Trusty image at this time hence you’ll need to explicitly specify `dist: trusty` in your .travis.yml file."

---

Needing to be on Ubuntu Trusty (14.04) seems new since last time this was all looked at, but I thought I'd try it to see if it allows our Travis CI tests to pass. Looks good on my fork (Travis passed).