### PR TITLE
Add Bathroom Editing Feature

### DIFF
--- a/app/src/main/java/org/refugerestrooms/views/AddBathroomFragment.java
+++ b/app/src/main/java/org/refugerestrooms/views/AddBathroomFragment.java
@@ -18,6 +18,7 @@ public class AddBathroomFragment extends Fragment {
 
     private WebView mWebView;
     private Bundle mWebViewBundle;
+    private String editParams;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -30,7 +31,7 @@ public class AddBathroomFragment extends Fragment {
         super.onAttach(context);
         // Pre-load the website into the cache when the fragment is first attached.
         WebView preWebView = new WebView(context);
-        preWebView.loadUrl("https://www.refugerestrooms.org/restrooms/new?");
+        preWebView.loadUrl("https://www.refugerestrooms.org/restrooms/new?" + editParams);
     }
 
     @Override
@@ -38,13 +39,13 @@ public class AddBathroomFragment extends Fragment {
         View rootView = inflater.inflate(R.layout.fragment_add_bathroom, container, false);
         mWebView = (WebView) rootView.findViewById(R.id.addBathroom);
         mWebView.getSettings().setJavaScriptEnabled(true);
-        mWebView.setWebViewClient(new AddBathroomClient("https://www.refugerestrooms.org/restrooms/new?"));
+        mWebView.setWebViewClient(new AddBathroomClient("https://www.refugerestrooms.org/restrooms/new?" + editParams));
 
         // If possible, restore the WebView state - otherwise load the new restroom page
         if (mWebViewBundle != null) {
             mWebView.restoreState(mWebViewBundle);
         } else {
-            mWebView.loadUrl("https://www.refugerestrooms.org/restrooms/new?");
+            mWebView.loadUrl("https://www.refugerestrooms.org/restrooms/new?" + editParams);
         }
 
         // Inflate the layout for this fragment
@@ -59,5 +60,10 @@ public class AddBathroomFragment extends Fragment {
         super.onPause();
         mWebViewBundle = new Bundle();
         mWebView.saveState(mWebViewBundle);
+    }
+
+    public void setEditId(String editId) {
+        this.editParams = editId != null ? "edit_id=" + editId + "&id=" + editId : "";
+        mWebViewBundle = null;
     }
 }

--- a/app/src/main/java/org/refugerestrooms/views/MainActivity.java
+++ b/app/src/main/java/org/refugerestrooms/views/MainActivity.java
@@ -164,7 +164,7 @@ public class MainActivity extends AppCompatActivity
     // Create hashmap to store bathrooms (Key = LatLng, Value = Bathroom)
     private final Map<LatLng, Bathroom> allBathroomsMap = new HashMap<>();
 
-    private Fragment addBathroomFragment;
+    private AddBathroomFragment addBathroomFragment;
     private FragmentManager fragmentManager;
 
     private Button mSearchHereButton;
@@ -414,6 +414,22 @@ public class MainActivity extends AppCompatActivity
                 Intent mapIntent = new Intent(Intent.ACTION_VIEW, intentUri);
                 mapIntent.setPackage("com.google.android.apps.maps");
                 startActivity(mapIntent);
+            }
+        });
+
+        findViewById(R.id.button_edit).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                mSearchHereButton.setVisibility(View.GONE);
+                mFab.setVisibility(View.GONE);
+                bottomSheet.setVisibility(View.INVISIBLE);
+
+                addBathroomFragment.setEditId(bathroom.getmId().toString());
+                fragmentManager.beginTransaction()
+                        .replace(R.id.container, addBathroomFragment)
+                        .addToBackStack("editBathroom")
+                        .commit();
+                setToolbarTitle(getString(R.string.edit_title_section));
             }
         });
     }
@@ -1242,6 +1258,8 @@ public class MainActivity extends AppCompatActivity
         } else if (id == R.id.nav_bathrooms) {
             Log.d("RefugeRestrooms", "Nav bathrooms");
             title = getString(R.string.saved_bathrooms);
+            fragment = new MapFragment();
+            fragmentTitle = "maps";
             List<BathroomEntity> bathroomsList = loadSavedBathrooms();
             DatabaseEntityConverter dataEntityConv = new DatabaseEntityConverter();
             List<Bathroom> bathrooms = dataEntityConv.convertBathroomEntity(bathroomsList);
@@ -1250,6 +1268,7 @@ public class MainActivity extends AppCompatActivity
             bottomSheet.setVisibility(View.VISIBLE);
             Snackbar.make(mFab, getString(R.string.loading_recent_bathrooms), Snackbar.LENGTH_SHORT).show();
         } else if (id == R.id.nav_add) {
+            addBathroomFragment.setEditId(null);
             title = getString(R.string.add_title_section);
             fragment = addBathroomFragment;
             fragmentTitle = "addBathroom";

--- a/app/src/main/res/layout/bottom_sheet_details.xml
+++ b/app/src/main/res/layout/bottom_sheet_details.xml
@@ -47,11 +47,24 @@
         android:id="@+id/button_maps"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/open_in_maps"
-        android:textColor="@android:color/white"
-        android:background="@color/ColorPrimaryDark"
         android:layout_below="@+id/text_comments"
-        android:layout_centerHorizontal="true" />
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_centerHorizontal="true"
+        android:background="@color/ColorPrimaryDark"
+        android:text="@string/open_in_maps"
+        android:textColor="@android:color/white" />
+
+    <Button
+        android:id="@+id/button_edit"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/button_maps"
+        android:layout_margin="8dp"
+        android:layout_centerHorizontal="true"
+        android:background="@color/ColorPrimaryDark"
+        android:text="@string/suggest_an_edit"
+        android:textColor="@android:color/white" />
 
     <TextView
         android:id="@+id/text_comments"
@@ -62,10 +75,11 @@
         android:layout_margin="8dp"
         android:background="@android:color/white"
         android:gravity="center_horizontal"
+
+        android:paddingBottom="12dp"
         android:textColor="@color/ColorComments"
         android:textIsSelectable="true"
         android:textSize="16sp"
-        android:paddingBottom="12dp"
-
         tools:text="@string/dir_comments_text" />
+
 </RelativeLayout>

--- a/app/src/main/res/values-es-rUS/strings.xml
+++ b/app/src/main/res/values-es-rUS/strings.xml
@@ -20,6 +20,7 @@
     <string name="add_bathroom_title">Enviar un baño a nuestra base de datos</string>
     <string name="add_bathroom_unisex">Unisexo</string>
     <string name="add_title_section">Añadir Baño</string>
+    <string name="edit_title_section">Editar Baño</string>
     <string name="bathroom_details_address">3320 Avenida Chicago, Minneapolis, MN, EE UU</string>
     <string name="connected">Conectado</string>
     <string name="fail_toast">Se produjo un error al enviar el baño</string>
@@ -43,6 +44,7 @@
     <string name="no_search_locations">No se encontraron baños en %1$s</string>
     <string name="no_search_locations_initial">"No se encontraron baños con búsqueda "</string>
     <string name="open_in_maps">Abrir en Google Maps</string>
+    <string name="suggest_an_edit">Sugerir una Edición</string>
     <string name="restrooms_found">Baños encontrados!</string>
     <string name="saved_bathrooms">Baños Recientes</string>
     <string name="score">Puntuación:</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="saved_bathrooms">Recent Bathrooms</string>
     <string name="map_title_section">Map</string>
     <string name="add_title_section">Add Bathroom</string>
+    <string name="edit_title_section">Edit Bathroom</string>
     <string name="feedback_title_section">Feedback</string>
     <string name="title_directions">Directions</string>
     <string name="email" translatable="false">refugerestroomsapp@gmail.com</string>
@@ -56,6 +57,7 @@
     <string name="add_bathroom_save">Save Restroom</string>
 
     <string name="open_in_maps">Open in Google Maps</string>
+    <string name="suggest_an_edit">Suggest an Edit</string>
     <string name="bathroom_details_cafe" translatable="false">Modern Times Cafe</string>
     <string name="bathroom_details_address">3200 Chicago Ave Minneapolis, MN, US</string>
 


### PR DESCRIPTION
# Summary
This adds an editing feature for bathrooms. The bathroom details section will now show a "Suggest an Edit" button. Clicking that button will open an Edit Bathroom view, which is actually just the Add Bathroom view with the editing URL query parameters included for the selected bathroom.

I also baked in a small change for the Recent Bathrooms menu item to open the map fragment. It previously did not change the view.

closes #82 
# Test Plan
I used an AVD emulator in Android Studio to manually test the changes (Pixel XL API 30).

Test Case 1:
1. Select a bathroom on the map
2. Open details section
3. Click Suggest an Edit button
4. Verify form is preloaded with the bathroom's info
4. Make edit
5. Click save restroom
6. Verify success message

![Screen Shot 2021-12-29 at 10 59 44 PM](https://user-images.githubusercontent.com/11550396/147728942-1aa4e574-c43c-441b-8ea3-0443504ac1c8.png)

![Screen Shot 2021-12-29 at 10 49 47 PM](https://user-images.githubusercontent.com/11550396/147728369-93497da4-ce88-41c9-90e5-0f0a212f96ec.png)

![Screen Shot 2021-12-29 at 10 50 29 PM](https://user-images.githubusercontent.com/11550396/147728402-352dd691-eb68-44b0-afc3-473739005c06.png)

Test Case 2:
1. Open the Edit Bathroom page as above
2. Use menu to go back to Map
3. Use menu to go back to Add Bathroom
4. Verify that the empty Add Bathroom page is shown instead of edit page

Test Case 3:
1. Open Add Bathroom through the menu
2. Click Recent Bathrooms in the menu
3. Verify map is shown