### PR TITLE
Allow current location option like in webapp

### DIFF
--- a/app/src/main/java/org/refugerestrooms/views/AddBathroomClient.java
+++ b/app/src/main/java/org/refugerestrooms/views/AddBathroomClient.java
@@ -4,7 +4,18 @@ package org.refugerestrooms.views;
  * Created by Refuge Restrooms on 7/14/2015.
  */
 
+import android.Manifest;
+import android.app.Activity;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.location.Address;
+import android.location.Geocoder;
+import android.location.Location;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
+import android.util.Log;
 import android.view.View;
+import android.webkit.JavascriptInterface;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
@@ -12,16 +23,30 @@ import android.webkit.WebViewClient;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.List;
+import java.util.Locale;
 
 public class AddBathroomClient extends WebViewClient {
     private String currentUrl;
+    private Context context;
+    private WebView view;
+    private Location mCurrentLocation;
 
     public AddBathroomClient() {
         super();
     }
 
-    public AddBathroomClient(String currentUrl) {
+//    public AddBathroomClient(String currentUrl) {
+//        this.currentUrl = currentUrl;
+//    }
+
+    // Markus: why are you using view here but WebView everywhere else in the code?
+    public AddBathroomClient(String currentUrl, Context context, WebView view, Location mCurrentLocation) {
         this.currentUrl = currentUrl;
+        this.context = context;
+        this.view = view;
+        this.mCurrentLocation = mCurrentLocation;
+        this.view.addJavascriptInterface(new JavaScriptInterface(context, this), "AndroidInterface");
     }
 
     /**
@@ -33,14 +58,14 @@ public class AddBathroomClient extends WebViewClient {
         try {
             // Test internet connection
             HttpURLConnection urlConnection = (HttpURLConnection)
-                (new URL("http://clients3.google.com/generate_204")
-                .openConnection());
+                    (new URL("http://clients3.google.com/generate_204")
+                            .openConnection());
             urlConnection.setRequestProperty("User-Agent", "Android");
             urlConnection.setRequestProperty("Connection", "close");
             urlConnection.setConnectTimeout(1500);
             urlConnection.connect();
             if (urlConnection.getResponseCode() == 204 &&
-                urlConnection.getContentLength() == 0) {
+                    urlConnection.getContentLength() == 0) {
                 // Successfully connected to the internet.
                 return true;
             } else {
@@ -50,7 +75,7 @@ public class AddBathroomClient extends WebViewClient {
             // No internet connection detected, or an error has been encountered.
             return false;
         }
-            
+
     }
 
     @Override
@@ -71,8 +96,6 @@ public class AddBathroomClient extends WebViewClient {
             //TODO Add no connection detected page to display here.
             return false;
         }*/
-        
-            
         // view.getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE);
         if (url.equals(currentUrl)) {
             view.loadUrl(url);
@@ -83,23 +106,95 @@ public class AddBathroomClient extends WebViewClient {
 
     @Override
     public void onPageFinished(final WebView view, String url) {
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED &&
+                ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+            ActivityCompat.requestPermissions((Activity) context, new String[]{Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION}, 1);
+        }
+
         // Removes header, footer -- areas where people can navigate away from the add a bathroom page
-        view.loadUrl("javascript:(function() { " +
+        view.evaluateJavascript("javascript:(function() { " +
                 "document.getElementsByTagName('header')[0].style.display='none'; " +
                 "document.getElementsByTagName('footer')[0].style.display='none';" +
                 "document.body.style.marginLeft=\"5%\";" +
                 "document.body.style.marginRight=\"5%\";" +
                 "document.body.style.backgroundColor=\"#e9e9e9\";" +
                 "document.body.style.color=\"#8377AF\";" +
-                "document.getElementsByTagName('h5')[0].style.display='none';" +
-                "document.getElementsByClassName('guess-btn')[0].style.display='none';" +
-                "})()");
+                "document.getElementByID('restroom_street')[0].style.display='none';" +
+                "document.getElementByID('restroom_street')[0].style.display='none';" +
+                "document.getElementByID('restroom_city')[0].style.display='none';" +
+                "document.getElementByID('restroom_state')[0].style.display='none';" +
+                "})()", null);
+
+
+        // Add the function to the button
+        view.evaluateJavascript("javascript:(function() { " +
+                "var button = document.getElementsByClassName('guess-btn')[0];" +
+                "if (button) { console.log('Button found'); } else { console.log('Button not found'); }" +
+                "button.onclick = function(event) {" +
+                "   event.preventDefault();" + // Prevent the default behavior of the button
+                "   AndroidInterface.getLocationAddress(" + mCurrentLocation.getLatitude() + ", " + mCurrentLocation.getLongitude() + ");" +
+                "};" +
+                "})()", null);
+
         // Time Delay to prevent display showing before javascript finishes
         view.postDelayed(new Runnable() {
             public void run() {
                 view.setVisibility(View.VISIBLE);
             }
         }, 50);
-
     }
+
+
+
+    /**
+     * Gets the location address from latitude and longitude and updates the input fields
+     * in the WebView with the address information.
+     *
+     * @param latitude  The latitude of the location.
+     * @param longitude The longitude of the location.
+     */
+    public void getLocationAddress(double latitude, double longitude) {
+        try {
+            Geocoder geocoder = new Geocoder(context, Locale.getDefault());
+            List<Address> addresses = geocoder.getFromLocation(latitude, longitude, 1);
+            if (addresses != null && !addresses.isEmpty()) {
+                final String address = addresses.get(0).getAddressLine(0);
+                final String[] addressParts = address.split(",");
+
+                // Print the address to the WebView
+                view.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        view.evaluateJavascript("javascript:(function() { " +
+                                "var inputElement = document.getElementById('restroom_street');" +
+                                "if (inputElement) {" +
+                                "    inputElement.value = '" + addressParts[0] + "';" +
+                                "} else {" +
+                                "    console.log('Input element with ID \\'restroom_street\\' not found.');" +
+                                "}" +
+                                "var inputElement = document.getElementById('restroom_city');" +
+                                "if (inputElement) {" +
+                                "    inputElement.value = '" + addressParts[1] + "';" +
+                                "} else {" +
+                                "    console.log('Input element with ID \\'restroom_city\\' not found.');" +
+                                "}" +
+                                "var inputElement = document.getElementById('restroom_state');" +
+                                "if (inputElement) {" +
+                                "    inputElement.value = '" + addressParts[2] + "';" +
+                                "} else {" +
+                                "    console.log('Input element with ID \\'restroom_state\\' not found.');" +
+                                "}" +
+                                "})()", null);
+                    }
+                });
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+
 }
+
+
+

--- a/app/src/main/java/org/refugerestrooms/views/AddBathroomFragment.java
+++ b/app/src/main/java/org/refugerestrooms/views/AddBathroomFragment.java
@@ -5,6 +5,7 @@ import android.content.Context;
  * Created by Refuge Restrooms on 7/14/2015.
  */
 
+import android.location.Location;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
@@ -19,6 +20,7 @@ public class AddBathroomFragment extends Fragment {
     private WebView mWebView;
     private Bundle mWebViewBundle;
     private String editParams;
+    private Location mCurrentLocation;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -39,7 +41,7 @@ public class AddBathroomFragment extends Fragment {
         View rootView = inflater.inflate(R.layout.fragment_add_bathroom, container, false);
         mWebView = (WebView) rootView.findViewById(R.id.addBathroom);
         mWebView.getSettings().setJavaScriptEnabled(true);
-        mWebView.setWebViewClient(new AddBathroomClient("https://www.refugerestrooms.org/restrooms/new?" + editParams));
+        mWebView.setWebViewClient(new AddBathroomClient("https://www.refugerestrooms.org/restrooms/new?" + editParams, getContext(), mWebView, mCurrentLocation));
 
         // If possible, restore the WebView state - otherwise load the new restroom page
         if (mWebViewBundle != null) {
@@ -65,5 +67,9 @@ public class AddBathroomFragment extends Fragment {
     public void setEditId(String editId) {
         this.editParams = editId != null ? "edit_id=" + editId + "&id=" + editId : "";
         mWebViewBundle = null;
+    }
+
+    public void setmCurrentLocation(Location location) {
+        this.mCurrentLocation = location;
     }
 }

--- a/app/src/main/java/org/refugerestrooms/views/JavaScriptInterface.java
+++ b/app/src/main/java/org/refugerestrooms/views/JavaScriptInterface.java
@@ -1,0 +1,19 @@
+package org.refugerestrooms.views;
+
+import android.content.Context;
+import android.webkit.JavascriptInterface;
+
+public class JavaScriptInterface {
+    private Context mContext;
+    private AddBathroomClient mAddBathroomClient;
+
+    public JavaScriptInterface(Context context, AddBathroomClient addBathroomClient) {
+        mContext = context;
+        mAddBathroomClient = addBathroomClient;
+    }
+
+    @JavascriptInterface
+    public void getLocationAddress(double latitude, double longitude) {
+        mAddBathroomClient.getLocationAddress(latitude, longitude);
+    }
+}

--- a/app/src/main/java/org/refugerestrooms/views/MainActivity.java
+++ b/app/src/main/java/org/refugerestrooms/views/MainActivity.java
@@ -884,6 +884,8 @@ public class MainActivity extends AppCompatActivity
                 mEditor.putLong("current_lon", Double.doubleToRawLongBits(mCurrentLocation.getLongitude()));
                 mEditor.commit();
             }
+
+            addBathroomFragment.setmCurrentLocation(this.mCurrentLocation);
         }
     }
 


### PR DESCRIPTION
This pull request adds location autofill functionality to the input fields for street, city, and state in the 'Add a Restroom' form. Users can now click a button to automatically populate the address fields with their current location, making it easier and more convenient to add restroom information.

Changes include:

- Added a mCurrentLocation variable inside AddBathroomFragment to keep track of the latest location of the user.
- Implemented getLocationAddress() method to retrieve the location address using Geocoder based on latitude and longitude.
- Updated onPageFinished() method to add a custom click event listener to the 'Autofill Location' button.

This update streamlines the restroom submission process for users, making it easier to contribute valuable information to the platform.

Please review the changes and provide feedback. If everything looks good, please feel free to merge this pull request.